### PR TITLE
Adding the Option to Remove a User from a Group

### DIFF
--- a/StandIn/StandIn/Program.cs
+++ b/StandIn/StandIn/Program.cs
@@ -870,6 +870,52 @@ namespace StandIn
             }
         }
 
+        public static void removeUserFromGroup(String sGroup, String sAddUser, String sDomain = "", String sUser = "", String sPass = "")
+        {
+            try
+            {
+                PrincipalContext pc = null;
+                if (!String.IsNullOrEmpty(sDomain) && !String.IsNullOrEmpty(sUser) && !String.IsNullOrEmpty(sPass))
+                {
+                    String sUserDomain = String.Format("{0}\\{1}", sDomain, sUser);
+                    pc = new PrincipalContext(ContextType.Domain, sDomain, sUser, sPass);
+                }
+                else
+                {
+                    pc = new PrincipalContext(ContextType.Domain);
+                }
+
+                Console.WriteLine("\n[?] Using DC : " + pc.ConnectedServer);
+
+                GroupPrincipal oGroup = GroupPrincipal.FindByIdentity(pc, sGroup);
+                Console.WriteLine("[?] Group    : " + oGroup.Name);
+                Console.WriteLine("    GUID     : " + oGroup.Guid.ToString());
+                if (oGroup == null)
+                {
+                    Console.WriteLine("[!] Failed to resolve group..");
+                }
+                else
+                {
+                    Console.WriteLine("\n[+] Removing user from group");
+                    oGroup.Members.Remove(pc, IdentityType.SamAccountName, sAddUser);
+                    oGroup.Save();
+                    Console.WriteLine("    |_ Success");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("[!] Failed remove user from group..");
+                if (ex.InnerException != null)
+                {
+                    Console.WriteLine("    |_ " + ex.InnerException.Message);
+                }
+                else
+                {
+                    Console.WriteLine("    |_ " + ex.Message);
+                }
+            }
+        }
+
         public static void getGroupMembership(String sGroup, String sDomain = "", String sUser = "", String sPass = "")
         {
             try
@@ -1663,7 +1709,11 @@ namespace StandIn
                         }
                         else if (!String.IsNullOrEmpty(ArgOptions.sGroup))
                         {
-                            if (!String.IsNullOrEmpty(ArgOptions.sNtaccount))
+                            if (!String.IsNullOrEmpty(ArgOptions.sNtaccount) && ArgOptions.bRemove)
+                            {
+                                removeUserFromGroup(ArgOptions.sGroup, ArgOptions.sNtaccount, ArgOptions.sDomain, ArgOptions.sUser, ArgOptions.sPass);
+                            }
+                            else if (!String.IsNullOrEmpty(ArgOptions.sNtaccount))
                             {
                                 addUserToGroup(ArgOptions.sGroup, ArgOptions.sNtaccount, ArgOptions.sDomain, ArgOptions.sUser, ArgOptions.sPass);
                             }

--- a/StandIn/StandIn/hStandIn.cs
+++ b/StandIn/StandIn/hStandIn.cs
@@ -162,6 +162,10 @@ namespace StandIn
                               "StandIn.exe --group \"Dunwich Council\" --ntaccount \"REDHOOK\\WWhateley\"\n" +
                               "StandIn.exe --group DAgon --ntaccount \"REDHOOK\\RCarter\" --domain redhook --user RFludd --pass Cl4vi$Alchemi4e\n\n" +
 
+                              "# Remove user from group\n" +
+                              "StandIn.exe --group \"Dunwich Council\" --ntaccount \"REDHOOK\\WWhateley\" --remove\n" +
+                              "StandIn.exe --group DAgon --ntaccount \"REDHOOK\\RCarter\" --domain redhook --user RFludd --pass Cl4vi$Alchemi4e --remove\n\n" +
+
                               "# Create machine object\n" +
                               "StandIn.exe --computer Innsmouth --make\n" +
                               "StandIn.exe --computer Innsmouth --make --domain redhook --user RFludd --pass Cl4vi$Alchemi4e\n\n" +


### PR DESCRIPTION
This PR adds the capability to remove a user from an Active Directory group. It is almost an exact copy of `addUserToGroup` but just uses `GroupPrincipal.Members.Remove()` instead of `.Add()`. The command line parsing logic now looks for `--group` passed with `--ntaccount` AND `--remove` to determine if it is a remove operation.

![standin-removeuserfromgroup](https://user-images.githubusercontent.com/1756781/107084635-4e037600-67c5-11eb-823b-b390e5c50435.png)
